### PR TITLE
installv3.sh: updated url for gcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Hexagon SDK [HEXAGON_SDK_ROOT]: ${HOME}/Qualcomm/Hexagon_SDK/3.0
 
 Hexagon Tools [HEXAGON_TOOLS_ROOT]: ${HOME}/Qualcomm/HEXAGON_Tools/7.2.12/Tools
 
-ARMv7hf cross compiler: ${HEXAGON_SDK_ROOT}/gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf_linux
+ARMv7hf cross compiler: ${HEXAGON_SDK_ROOT}/gcc-linaro-4.9-2016.02-x86_64_arm-linux-gnueabihf_linux
 
 You can re-run installv3.sh as many times as you like and it will only install missing pieces and then display the environment variables to set.
 These can be copied and pasted into the shell for convienience.

--- a/installv3.sh
+++ b/installv3.sh
@@ -134,16 +134,16 @@ else
 fi
 
 # Fetch ARMv7hf cross compiler
-if [ ! -f downloads/gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf.tar.xz ]; then
-	wget -P downloads https://releases.linaro.org/14.11/components/toolchain/binaries/arm-linux-gnueabihf/gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf.tar.xz
+if [ ! -f downloads/gcc-linaro-4.9-2016.02-x86_64_arm-linux-gnueabihf.tar.xz ]; then
+	wget -P downloads https://releases.linaro.org/components/toolchain/binaries/4.9-2016.02/arm-linux-gnueabihf/gcc-linaro-4.9-2016.02-x86_64_arm-linux-gnueabihf.tar.xz
 fi
 
 # Unpack armhf cross compiler
-if [ ! -d ${HEXAGON_SDK_ROOT}/gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf_linux ]; then
+if [ ! -d ${HEXAGON_SDK_ROOT}/gcc-linaro-4.9-2016.02-x86_64_arm-linux-gnueabihf_linux ]; then
 	echo "Unpacking cross compiler..."
-	tar -C ${HEXAGON_SDK_ROOT} -xJf downloads/gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf.tar.xz
+	tar -C ${HEXAGON_SDK_ROOT} -xJf downloads/gcc-linaro-4.9-2016.02-x86_64_arm-linux-gnueabihf.tar.xz
 	# The SDK added a _linux extension
-	mv ${HEXAGON_SDK_ROOT}/gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf ${HEXAGON_SDK_ROOT}/gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf_linux
+	mv ${HEXAGON_SDK_ROOT}/gcc-linaro-4.9-2016.02-x86_64_arm-linux-gnueabihf ${HEXAGON_SDK_ROOT}/gcc-linaro-4.9-2016.02-x86_64_arm-linux-gnueabihf_linux
 fi
 
 if [ ! -f ${HEXAGON_SDK_ROOT}/libs/common/rpcmem/UbuntuARM_Debug/rpcmem.a ]; then
@@ -206,10 +206,10 @@ fi
 
 echo Done
 echo "--------------------------------------------------------------------"
-echo "armhf cross compiler is at: ${HEXAGON_SDK_ROOT}/gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf_linux"
+echo "armhf cross compiler is at: ${HEXAGON_SDK_ROOT}/gcc-linaro-4.9-2016.02-x86_64_arm-linux-gnueabihf_linux"
 echo
 echo "Make sure to set the following environment variables:"
 echo "   export HEXAGON_SDK_ROOT=${HEXAGON_SDK_ROOT}"
 echo "   export HEXAGON_TOOLS_ROOT=${HEXAGON_TOOLS_ROOT}"
-echo "   export PATH=\${HEXAGON_SDK_ROOT}/gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf_linux/bin:\$PATH"
+echo "   export PATH=\${HEXAGON_SDK_ROOT}/gcc-linaro-4.9-2016.02-x86_64_arm-linux-gnueabihf_linux/bin:\$PATH"
 echo


### PR DESCRIPTION
The original URL doesn't seem to be available any longer and gives a
404.

Unforunately, `installv3.sh` still fails somehow and I can't figure out why:

```
2016-11-23 20:08:33 (1.99 MB/s) - 'downloads/gcc-linaro-4.9-2016.02-x86_64_arm-linux-gnueabihf.tar.xz' saved [144578504/144578504]

Unpacking cross compiler...
~/cross_toolchain ~/cross_toolchain
../../../build/make.d.ext/UbuntuARM/../../../gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf_linux/bin/arm-linux-gnueabihf-gcc -c -fPIC -Wall -Wno-missing-braces -mword-relocations -mthumb-interwork -mfloat-abi=hard -mfpu=neon -mtune=cortex-a8 -march=armv7-a -Werror -g -isystem ../../../build/make.d.ext/UbuntuARM/../../../gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf_linux/arm-linux-gnueabihf/libc/usr/include -DARM_ARCH_7A -DUSE_SYSLOG -std=gnu99      -D__FILENAME__=\"rpcmem.c\" -D_DEBUG  -Iinc -Isrc -I../../../incs/a1std -I../../../incs/qlist -I../../../incs/stddef -IUbuntuARM_Debug  -oUbuntuARM_Debug/rpcmem.o src/rpcmem.c
make: ../../../build/make.d.ext/UbuntuARM/../../../gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf_linux/bin/arm-linux-gnueabihf-gcc: Command not found
../../../build/make.d/rules.min:589: recipe for target 'UbuntuARM_Debug/rpcmem.o' failed
make: *** [UbuntuARM_Debug/rpcmem.o] Error 127
Error: Script aborted
The command '/bin/sh -c cd /home/docker1000/cross_toolchain     && ./installv3.sh' returned a non-zero code: 1
```

@jywilson @bharath374 @mcharleb